### PR TITLE
Added H.264 and VP8 video

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,6 +256,36 @@
               <td colspan="7">An alternative to the PeerConnection API defined by the W3C ORTC Community Group. A prototype plugin for Chrome and Internet Explorer is available from <a href="http://msopentech.com/blog/2014/04/25/updated-ortc-api-prototype-released/">MS Open Tech</a>. This will be superseeded by <a href="http://blogs.msdn.com/b/ie/archive/2014/10/27/bringing-interoperable-real-time-communications-to-the-web.aspx">native integration in Internet Explorer</a> at some point.</td>
             </tr>
             <tr>
+              <th><a href="#h264">H.264 video</a></th>
+              <td class="no"></td>
+              <td class="no"></td>
+              <td class="no"></td>
+              <td class="yes"></td>
+              <td class="yes"></td>
+              <td class="yes"></td>
+              <td class="no"></td>
+              <td class="no"></td>
+            </tr>
+            <tr class="about">
+              <th></th>
+              <td colspan="7">Support for H.264 video. A WebRTC compliant browser should support both H.264 and VP8 video.</td>
+            </tr>
+            <tr>
+              <th><a href="#vp8">VP8 video</a></th>
+              <td class="yes"></td>
+              <td class="yes"></td>
+              <td class="yes"></td>
+              <td class="yes"></td>
+              <td class="yes"></td>
+              <td class="yes"></td>
+              <td class="no"></td>
+              <td class="no"></td>
+            </tr>
+            <tr class="about">
+              <th></th>
+              <td colspan="7">Support for VP8 video. A WebRTC compliant browser should support both H.264 and VP8 video.</td>
+            </tr>
+            <tr>
               <th><a href="#echo">Solid interoperability</a></th>
               <td class="inc"></td>
               <td class="inc"></td>


### PR DESCRIPTION
A WebRTC compliant browser should support both H.264 and VP8 video.
