### PR TITLE
Added 'srcObject' to the list.

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,6 +270,22 @@
               <th></th>
               <td colspan="7">Multiple browsers consistently being able to talk to each other is essential to making WebRTC a true web technology and not just something that makes for a nice demo.              </td>
             </tr>
+            <tr>
+              <th><a href="#srcobject">srcObject in media element</a></th>
+              <td class="no"></td>
+              <td class="no"></td>
+              <td class="no"></td>
+              <td class="yes"></td>
+              <td class="yes"></td>
+              <td class="no"></td>
+              <td class="no"></td>
+              <td class="no"></td>
+            </tr>
+            <tr class="about">
+              <th></th>
+              <td colspan="7">srcObject is the way to indicate to a video or audio element that it should
+              play a MediaStream (createObjectURL obsoleted in std).             </td>
+            </tr>
           </table>
         </div>
         <p>See an error? This site is open source on Github, please let us know by <a href="https://github.com/andyet/iswebrtcreadyyet.com/issues">opening an issue</a>.</p>


### PR DESCRIPTION
BTW, talky.io (promoted by iswebrtcreadyyet) flat out refuses all implementations except Chrome, Firefox and Opera. IMO it should do a feature check instead.
