### PR TITLE
Added gUM with Promise hanging off mediaDevices.

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,6 +316,21 @@
               <td colspan="7">srcObject is the way to indicate to a video or audio element that it should
               play a MediaStream (createObjectURL obsoleted in std).             </td>
             </tr>
+            <tr>
+              <th><a href="#promisegum">Promise based getUserMedia</a></th>
+              <td class="no"></td>
+              <td class="no"></td>
+              <td class="no"></td>
+              <td class="yes"></td>
+              <td class="no"></td>
+              <td class="no"></td>
+              <td class="no"></td>
+              <td class="no"></td>
+            </tr>
+            <tr class="about">
+              <th></th>
+              <td colspan="7">GetUserMedia has moved to mediaDevices (instead of hanging directly on navigator), and uses Promises instead of callbacks.             </td>
+            </tr>
           </table>
         </div>
         <p>See an error? This site is open source on Github, please let us know by <a href="https://github.com/andyet/iswebrtcreadyyet.com/issues">opening an issue</a>.</p>


### PR DESCRIPTION
I don't know to what level of detail you want to go. Anyway, in later versions of the spec getUserMedia hangs off mediaDevices (not directly off navigator) as in navigator.mediaDevices.getUserMedia, and also uses Promises instead of callback. Is supported by FF nightly.
