### PR TITLE
PeerConnection promises

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,7 +332,7 @@
               <td colspan="7">GetUserMedia has moved to mediaDevices (instead of hanging directly on navigator), and uses Promises instead of callbacks.             </td>
             </tr>
             <tr>
-              <th><a href="#promisegum">Promise based PeerConnection API</a></th>
+              <th><a href="#promisepc">Promise based PeerConnection API</a></th>
               <td class="no"></td>
               <td class="no"></td>
               <td class="no"></td>

--- a/index.html
+++ b/index.html
@@ -331,6 +331,21 @@
               <th></th>
               <td colspan="7">GetUserMedia has moved to mediaDevices (instead of hanging directly on navigator), and uses Promises instead of callbacks.             </td>
             </tr>
+            <tr>
+              <th><a href="#promisegum">Promise based PeerConnection API</a></th>
+              <td class="no"></td>
+              <td class="no"></td>
+              <td class="no"></td>
+              <td class="yes"></td>
+              <td class="no"></td>
+              <td class="yes"></td>
+              <td class="no"></td>
+              <td class="no"></td>
+            </tr>
+            <tr class="about">
+              <th></th>
+              <td colspan="7">According to the latest W3C specification Promises should be used instead of callbacks.</td>
+            </tr>
           </table>
         </div>
         <p>See an error? This site is open source on Github, please let us know by <a href="https://github.com/andyet/iswebrtcreadyyet.com/issues">opening an issue</a>.</p>


### PR DESCRIPTION
According to the latest W3C specification Promises should be used instead of callbacks. Supported by Firefox Nightly and Bowser.
