### PR TITLE
Add Safari iOS support

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
               <th><img src="images/bowser.png" alt="Bowser" title="Bowser"></th>
               <th><img src="images/edge.png" alt="Edge" title="Microsoft Edge"></th>
               <th><img src="images/safari.png" alt="Safari" title="Safari"></th>
+              <th><img src="images/safari.png" alt="Safari iOS" title="Safari iOS"></th>
             </tr>
             <tr class="versions">
               <th>Canary</th>
@@ -34,6 +35,7 @@
               <th>Bowser</th>
               <th>Edge</th>
               <th>Safari</th>
+              <th>Safari iOS</th>
             </tr>
             <tr>
               <td class="yes">&nbsp;</td>
@@ -44,6 +46,7 @@
               <td class="yes"></td>
               <td class="yes"></td>
               <td class="inc"></td>
+              <td class="no"></td>
             </tr>
           </table>
           <h4>There are lots of issues and bugs remaining of course. <a href="http://code.google.com/p/webrtc">Report</a> <a href="https://bugzilla.mozilla.org/">bugs</a> when that is not the case or use a shim like <a href="https://github.com/webrtc/adapter">adapter.js</a> until implementations match the specification.</h4>


### PR DESCRIPTION
Currently there are too many serious bugs affecting Safari on iOS for it to be used in production by anyone. Therefore we must add a not supported for Safari on iOS specifically. Attempt to use it at your own risk!

Bugs that are currently breaking production use of Safari on iOS:
- https://bugs.webkit.org/show_bug.cgi?id=179964
- https://bugs.webkit.org/show_bug.cgi?id=181009
- https://bugs.webkit.org/show_bug.cgi?id=180748

List of bugs for Safari WebRTC:
https://bugs.webkit.org/buglist.cgi?bug_status=__open__&component=WebRTC&list_id=3330069&product=WebKit